### PR TITLE
🐛 fix bug on SAN cache

### DIFF
--- a/src/Chess.php
+++ b/src/Chess.php
@@ -1040,6 +1040,8 @@ class Chess
     {
         $cacheKey = json_encode($move).$this->boardHash;
         if (isset($this->sanMoveCache[$cacheKey])) {
+            $move->san = $this->sanMoveCache[$cacheKey];
+
             return;
         }
 

--- a/tests/MiscTest.php
+++ b/tests/MiscTest.php
@@ -12,7 +12,7 @@ class MiscTest extends TestCase
     {
         $chess = new ChessPublicator();
         $moves = ['e4','e6','d4','d5','Nc3','Nf6','Bg5','dxe4','Nxe4','Be7','Bxf6','gxf6','g3','f5','Nc3','Bf6'];
-        
+
         foreach ($moves as $move) {
             $this->assertNotNull($chess->move($move), $move);
         }
@@ -23,15 +23,26 @@ class MiscTest extends TestCase
     {
         $chess = new ChessPublicator();
         $moves = ['e4','e6','d4','d5','Nc3','Nf6','Bg5','dxe4','Nxe4','Be7','Bxf6','gxf6','g3','f5','Nc3','Bf6'];
-        
+
         foreach ($moves as $move) {
             $this->assertNotNull($chess->move($move), $move);
         }
         $histories = $chess->history(['verbose' => true]);
-        
-        $this->assertSame(count($histories), count($moves));
+
+        $this->assertCount(count($histories), $moves);
         foreach ($histories as $k => $history) {
             $this->assertSame($history->san, $moves[$k]);
+        }
+    }
+
+    public function testCachedGeneratedMovesHasSAN(): void
+    {
+        $chess = new ChessPublicator();
+        // double call to moves method needed to enable caching
+        $chess->moves();
+        $moves = $chess->moves();
+        foreach ($moves as $move) {
+            $this->assertNotNull($move->san);
         }
     }
 }

--- a/tests/PgnTest.php
+++ b/tests/PgnTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PChess\Chess\Test;
 
-use PChess\Chess\Chess;
 use PChess\Chess\Validation;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
I just realized that last refactoring missed the attribution of SAN to Move object, if cached.
This PR fixes it.