### PR TITLE
Migrate PHPUnit configuration

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -9,20 +10,21 @@
          stopOnFailure="false"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 >
+    <coverage>
+        <include>
+            <directory>./src</directory>
+        </include>
+    </coverage>
+
     <testsuites>
         <testsuite name="Chess.php Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
 
-	<listeners>
-		<listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
-	</listeners>
-
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-        </whitelist>
-    </filter>
+    <listeners>
+        <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener"/>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
# Changed log

- Migrating the PHPUnit configuration to resolve following message:

```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```