### PR TITLE
🎨 check FEN on Chess constructor

### DIFF
--- a/src/Board.php
+++ b/src/Board.php
@@ -100,7 +100,7 @@ class Board implements \ArrayAccess, \Iterator, \JsonSerializable
      */
     public function offsetGet($offset): ?Piece
     {
-        return $this->squares[$offset];
+        return $this->squares[$offset] ?? null;
     }
 
     /**

--- a/src/Chess.php
+++ b/src/Chess.php
@@ -34,7 +34,9 @@ class Chess
     public function __construct(?string $fen = Board::DEFAULT_POSITION)
     {
         $this->board = new Board();
-        $this->load($fen);
+        if (null !== $error = $this->load($fen)) {
+            throw new \InvalidArgumentException(\sprintf('Invalid fen: %s. Error: %s', $fen, $error));
+        }
     }
 
     public function clear(): void
@@ -98,10 +100,11 @@ class Chess
         return $this->header;
     }
 
-    public function load(string $fen): bool
+    public function load(string $fen): ?string
     {
-        if (!Validation::validateFen($fen)['valid']) {
-            return false;
+        $result = Validation::validateFen($fen);
+        if (!$result['valid']) {
+            return $result['error'];
         }
         $tokens = \explode(' ', $fen);
         $this->clear();
@@ -150,7 +153,7 @@ class Chess
 
         $this->updateSetup($this->fen());
 
-        return true;
+        return null;
     }
 
     public function fen(): string
@@ -643,6 +646,7 @@ class Chess
                     $sanOrArray['to'] === $move->to
                 ) {
                     $moveObject = $move;
+                    $this->moveToSAN($moveObject);
                     break;
                 }
             }
@@ -652,7 +656,6 @@ class Chess
             return null;
         }
 
-        $this->moveToSAN($moveObject);
         $this->makeMove($moveObject);
 
         return $moveObject;

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -93,8 +93,8 @@ class Validation
 
         // 11th criterion: en-passant if last is black's move, then its must be white turn
         if (\strlen($tokens[3]) > 1) {
-            if (($tokens[3][1] == '3' && $tokens[1] === 'w') ||
-                ($tokens[3][1] == '6' && $tokens[1] === 'b')) {
+            if (($tokens[3][1] === '3' && $tokens[1] === 'w') ||
+                ($tokens[3][1] === '6' && $tokens[1] === 'b')) {
                 return ['valid' => false, 'error_number' => 11, 'error' => $errors[11]];
             }
         }

--- a/tests/ConstructorTest.php
+++ b/tests/ConstructorTest.php
@@ -21,6 +21,12 @@ class ConstructorTest extends TestCase
         self::assertEquals($output->render($a), $output->render($b));
     }
 
+    public function testInvalidFen(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Chess('an invalid fen string');
+    }
+
     public function testUnicodeOutput(): void
     {
         $chess = new Chess();

--- a/tests/PiecePlacementTest.php
+++ b/tests/PiecePlacementTest.php
@@ -38,6 +38,6 @@ class PiecePlacementTest extends TestCase
     {
         $chess = new Chess('8/8/8/8/8/8/8/8 w KQkq - 0 1');
         $result = $chess->load('invalid FEN string');
-        self::assertFalse($result);
+        self::assertNotNull($result);
     }
 }


### PR DESCRIPTION
While debugging an application, I realized that we don't check for a valid FEN passed to the constructor.
In this commit, I also changed the `load` method signature, to return its error instead of a simple boolean.
A couple of side changes:
1) in some rare conditions, offset in Board is not present (raising a notice).
2) remove a duplicate call to `moveToSAN`
