### PR TITLE
🎨 make load/clear methods protected

### DIFF
--- a/src/Board.php
+++ b/src/Board.php
@@ -12,6 +12,8 @@ class Board implements \ArrayAccess, \Iterator, \JsonSerializable
 {
     public const DEFAULT_POSITION = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
+    public const EMPTY = '8/8/8/8/8/8/8/8 w - - 0 1';
+
     public const SQUARES = [
         'a8' => 0, 'b8' => 1, 'c8' => 2, 'd8' => 3, 'e8' => 4, 'f8' => 5, 'g8' => 6, 'h8' => 7,
         'a7' => 16, 'b7' => 17, 'c7' => 18, 'd7' => 19, 'e7' => 20, 'f7' => 21, 'g7' => 22, 'h7' => 23,

--- a/src/Chess.php
+++ b/src/Chess.php
@@ -34,12 +34,12 @@ class Chess
     public function __construct(?string $fen = Board::DEFAULT_POSITION)
     {
         $this->board = new Board();
-        if (null !== $error = $this->load($fen)) {
+        if (null !== $error = $this->load($fen ?? Board::DEFAULT_POSITION)) {
             throw new \InvalidArgumentException(\sprintf('Invalid fen: %s. Error: %s', $fen, $error));
         }
     }
 
-    public function clear(): void
+    protected function clear(): void
     {
         $boardHash = \json_encode($this->board);
         $this->boardHash = false === $boardHash ? '' : $boardHash;
@@ -78,7 +78,7 @@ class Chess
     private static function addMove(string $turn, Board $board, array &$moves, int $from, int $to, int $flags): void
     {
         // if pawn promotion
-        if ($board[$from]->isPawn() && (Board::rank($to) === Board::RANK_8 || Board::rank($to) === Board::RANK_1)) {
+        if (isset($board[$from]) && $board[$from]->isPawn() && (Board::rank($to) === Board::RANK_8 || Board::rank($to) === Board::RANK_1)) {
             $promotionPieces = [Piece::QUEEN, Piece::ROOK, Piece::BISHOP, Piece::KNIGHT];
             foreach ($promotionPieces as $promotionPiece) {
                 $moves[] = Move::buildMove($turn, $board, $from, $to, $flags, $promotionPiece);
@@ -100,7 +100,7 @@ class Chess
         return $this->header;
     }
 
-    public function load(string $fen): ?string
+    protected function load(string $fen): ?string
     {
         $result = Validation::validateFen($fen);
         if (!$result['valid']) {

--- a/src/Move.php
+++ b/src/Move.php
@@ -66,6 +66,9 @@ final class Move implements \JsonSerializable
         if ($promotion !== null) {
             $flags |= Board::BITS['PROMOTION'];
         }
+        if (!isset($board[$from])) {
+            throw new \InvalidArgumentException('Invalid from: '.$from);
+        }
 
         return new self(
             $turn,

--- a/tests/AttackTest.php
+++ b/tests/AttackTest.php
@@ -143,27 +143,27 @@ class AttackTest extends TestCase
     public function testInsufficientMaterial(): void
     {
         // k vs k
-        $chess = new ChessPublicator('8/8/8/8/8/8/8/8 w - - 0 1');
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'e1');
         $chess->put(new Piece(Piece::KING, Piece::BLACK), 'e8');
         self::assertTrue($chess->insufficientMaterial());
 
         // k vs kn
-        $chess = new ChessPublicator('8/8/8/8/8/8/8/8 w - - 0 1');
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'e1');
         $chess->put(new Piece(Piece::KING, Piece::BLACK), 'e8');
         $chess->put(new Piece(Piece::KNIGHT, Piece::WHITE), 'e4');
         self::assertTrue($chess->insufficientMaterial());
 
         // k vs kb
-        $chess = new ChessPublicator('8/8/8/8/8/8/8/8 w - - 0 1');
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'e1');
         $chess->put(new Piece(Piece::KING, Piece::BLACK), 'e8');
         $chess->put(new Piece(Piece::BISHOP, Piece::WHITE), 'e4');
         self::assertTrue($chess->insufficientMaterial());
 
         // k vs k(b){0,} << bishop(s) in same color
-        $chess = new ChessPublicator('8/8/8/8/8/8/8/8 w - - 0 1');
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'e1');
         $chess->put(new Piece(Piece::KING, Piece::BLACK), 'e8');
         $chess->put(new Piece(Piece::BISHOP, Piece::BLACK), 'e5');

--- a/tests/AttackTest.php
+++ b/tests/AttackTest.php
@@ -12,8 +12,7 @@ class AttackTest extends TestCase
 {
     public function testAttackedPawn(): void
     {
-        $chess = new ChessPublicator();
-        $chess->clear();
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::PAWN, Piece::WHITE), 'e4');
         self::assertFalse($chess->attackedPublic(Piece::WHITE, Board::SQUARES['d3']));
         self::assertFalse($chess->attackedPublic(Piece::WHITE, Board::SQUARES['e3']));
@@ -30,8 +29,7 @@ class AttackTest extends TestCase
 
     public function testAttackedKnight(): void
     {
-        $chess = new ChessPublicator();
-        $chess->clear();
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::KNIGHT, Piece::WHITE), 'e4');
         self::assertTrue($chess->attackedPublic(Piece::WHITE, Board::SQUARES['d2']));
         self::assertTrue($chess->attackedPublic(Piece::WHITE, Board::SQUARES['d6']));
@@ -55,8 +53,7 @@ class AttackTest extends TestCase
 
     public function testAttackedBishop(): void
     {
-        $chess = new ChessPublicator();
-        $chess->clear();
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::BISHOP, Piece::WHITE), 'e4');
         self::assertTrue($chess->attackedPublic(Piece::WHITE, Board::SQUARES['d3']));
         self::assertTrue($chess->attackedPublic(Piece::WHITE, Board::SQUARES['d5']));
@@ -71,8 +68,7 @@ class AttackTest extends TestCase
 
     public function testAttackedRook(): void
     {
-        $chess = new ChessPublicator();
-        $chess->clear();
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::ROOK, Piece::WHITE), 'e4');
         self::assertFalse($chess->attackedPublic(Piece::WHITE, Board::SQUARES['d3']));
         self::assertFalse($chess->attackedPublic(Piece::WHITE, Board::SQUARES['d5']));
@@ -89,8 +85,7 @@ class AttackTest extends TestCase
 
     public function testAttackedQueen(): void
     {
-        $chess = new ChessPublicator();
-        $chess->clear();
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::QUEEN, Piece::WHITE), 'e4');
         self::assertTrue($chess->attackedPublic(Piece::WHITE, Board::SQUARES['d3']));
         self::assertTrue($chess->attackedPublic(Piece::WHITE, Board::SQUARES['d4']));
@@ -105,8 +100,7 @@ class AttackTest extends TestCase
 
     public function testAttackedKing(): void
     {
-        $chess = new ChessPublicator();
-        $chess->clear();
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'e4');
         self::assertTrue($chess->attackedPublic(Piece::WHITE, Board::SQUARES['d3']));
         self::assertTrue($chess->attackedPublic(Piece::WHITE, Board::SQUARES['d4']));
@@ -121,8 +115,7 @@ class AttackTest extends TestCase
 
     public function testInCheck(): void
     {
-        $chess = new ChessPublicator();
-        $chess->clear();
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'e7');
         $chess->put(new Piece(Piece::QUEEN, Piece::BLACK), 'e4');
         self::assertSame($chess->turn, Piece::WHITE);
@@ -135,51 +128,42 @@ class AttackTest extends TestCase
 
     public function testInCheckmate(): void
     {
-        $chess = new ChessPublicator();
-        self::assertFalse($chess->inCheckmate());
-
-        $chess->load('r1bqk1nr/pppp1Qpp/2n5/2b1p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4');
+        $chess = new ChessPublicator('r1bqk1nr/pppp1Qpp/2n5/2b1p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4');
         self::assertTrue($chess->inCheckmate());
     }
 
     public function testInStalemate(): void
     {
-        $chess = new ChessPublicator();
-        self::assertFalse($chess->inStalemate());
-
         // fen source: https://www.redhotpawn.com/forum/only-chess/interesting-stalemate-position.152109
         // start fen : 3b3k/p6p/1p5P/3q4/8/n7/PP6/K4Q2 w - - 0 1
-        $chess->load('7k/p6p/1p3b1P/3q4/8/n7/PP6/K7 w - - 0 2');
+        $chess = new ChessPublicator('7k/p6p/1p3b1P/3q4/8/n7/PP6/K7 w - - 0 2');
         self::assertTrue($chess->inStalemate());
     }
 
     public function testInsufficientMaterial(): void
     {
-        $chess = new ChessPublicator();
-        self::assertFalse($chess->insufficientMaterial());
-
         // k vs k
-        $chess->clear();
+        $chess = new ChessPublicator('8/8/8/8/8/8/8/8 w - - 0 1');
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'e1');
         $chess->put(new Piece(Piece::KING, Piece::BLACK), 'e8');
         self::assertTrue($chess->insufficientMaterial());
 
         // k vs kn
-        $chess->clear();
+        $chess = new ChessPublicator('8/8/8/8/8/8/8/8 w - - 0 1');
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'e1');
         $chess->put(new Piece(Piece::KING, Piece::BLACK), 'e8');
         $chess->put(new Piece(Piece::KNIGHT, Piece::WHITE), 'e4');
         self::assertTrue($chess->insufficientMaterial());
 
         // k vs kb
-        $chess->clear();
+        $chess = new ChessPublicator('8/8/8/8/8/8/8/8 w - - 0 1');
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'e1');
         $chess->put(new Piece(Piece::KING, Piece::BLACK), 'e8');
         $chess->put(new Piece(Piece::BISHOP, Piece::WHITE), 'e4');
         self::assertTrue($chess->insufficientMaterial());
 
         // k vs k(b){0,} << bishop(s) in same color
-        $chess->clear();
+        $chess = new ChessPublicator('8/8/8/8/8/8/8/8 w - - 0 1');
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'e1');
         $chess->put(new Piece(Piece::KING, Piece::BLACK), 'e8');
         $chess->put(new Piece(Piece::BISHOP, Piece::BLACK), 'e5');

--- a/tests/ConstructorTest.php
+++ b/tests/ConstructorTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PChess\Chess\Test;
 
 use Imagine\Image\AbstractImagine;
-use PChess\Chess\Board;
 use PChess\Chess\Chess;
 use PChess\Chess\Output;
 use PHPUnit\Framework\TestCase;
@@ -16,7 +15,6 @@ class ConstructorTest extends TestCase
     {
         $a = new Chess();
         $b = new Chess();
-        $b->load(Board::DEFAULT_POSITION);
         $output = new Output\AsciiOutput();
         self::assertEquals($output->render($a), $output->render($b));
     }

--- a/tests/FenTest.php
+++ b/tests/FenTest.php
@@ -11,13 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class FenTest extends TestCase
 {
-    public function testClear(): void
-    {
-        $chess = new Chess();
-        $chess->clear();
-        self::assertSame($chess->fen(), '8/8/8/8/8/8/8/8 w - - 0 1');
-    }
-
     public function testLoad(): void
     {
         $positions = [
@@ -268,9 +261,8 @@ class FenTest extends TestCase
             ['fen' => '3r1r2/3P2pk/1p1R3p/1Bp2p2/6q1/4Q3/PP3P1P/7K w - - 4 30', 'error_number' => 0, 'should_pass' => true],
         ];
 
-        $chess = new Chess();
         foreach ($positions as $position) {
-            $chess->load($position['fen']);
+            $chess = new Chess($position['fen']);
             self::assertEquals($position['fen'], $chess->fen());
         }
     }

--- a/tests/MoveTest.php
+++ b/tests/MoveTest.php
@@ -14,8 +14,7 @@ class MoveTest extends TestCase
 {
     public function testBuildMove(): void
     {
-        $chess = new ChessPublicator();
-        $chess->clear();
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::PAWN, Piece::WHITE), 'a2');
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'e7');
         $chess->put(new Piece(Piece::KING, Piece::BLACK), 'a7');
@@ -37,6 +36,13 @@ class MoveTest extends TestCase
         self::assertSame($move->flags, Board::BITS['NORMAL']);
     }
 
+    public function testBuildMoveWithInvalidFrom(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $chess = new Chess();
+        Move::buildMove('w', $chess->board, 999, 2, 0);
+    }
+
     public function testPutOnInvalidSquare(): void
     {
         $chess = new ChessPublicator();
@@ -49,8 +55,7 @@ class MoveTest extends TestCase
      */
     public function testMakeMoveAndCheckHistory(): void
     {
-        $chess = new ChessPublicator();
-        $chess->clear();
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::PAWN, Piece::WHITE), 'a2');
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'e7');
         $chess->put(new Piece(Piece::KING, Piece::BLACK), 'a7');
@@ -75,7 +80,7 @@ class MoveTest extends TestCase
         self::assertSame($lastHistory->moveNumber, 1);
 
         // promotions
-        $chess->load('8/P7/8/8/8/8/8/K6k w - - 0 1');
+        $chess = new ChessPublicator('8/P7/8/8/8/8/8/K6k w - - 0 1');
         $move = (ChessPublicator::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -90,15 +95,14 @@ class MoveTest extends TestCase
 
     public function testUndoMoveAndCheckHistory(): void
     {
-        $chess = new ChessPublicator();
-        $chess->clear();
+        $chess = new ChessPublicator(Board::EMPTY);
         $chess->put(new Piece(Piece::KING, Piece::WHITE), 'a1');
         $chess->put(new Piece(Piece::KING, Piece::BLACK), 'h1');
         $chess->put(new Piece(Piece::PAWN, Piece::WHITE), 'a7');
         $fenStart = $chess->fen();
 
         // normal move
-        $chess->load($fenStart);
+        $chess = new ChessPublicator($fenStart);
         $move = (ChessPublicator::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -112,7 +116,7 @@ class MoveTest extends TestCase
         self::assertSame($chess->fen(), $fenStart);
 
         // big pawn
-        $chess->load($fenStart);
+        $chess = new ChessPublicator($fenStart);
         $chess->put(new Piece(Piece::PAWN, Piece::WHITE), 'd2');
         $fenStart = $chess->fen();
         $move = (ChessPublicator::buildMovePublic(
@@ -128,7 +132,7 @@ class MoveTest extends TestCase
         self::assertSame($chess->fen(), $fenStart);
 
         // capture
-        $chess->load($fenStart);
+        $chess = new ChessPublicator($fenStart);
         $chess->put(new Piece(Piece::PAWN, Piece::BLACK), 'e5');
         $chess->put(new Piece(Piece::PAWN, Piece::WHITE), 'd4');
         $fenStart = $chess->fen();
@@ -145,7 +149,7 @@ class MoveTest extends TestCase
         self::assertSame($chess->fen(), $fenStart);
 
         // en passant
-        $chess->load($fenStart);
+        $chess = new ChessPublicator($fenStart);
         $chess->put(new Piece(Piece::PAWN, Piece::BLACK), 'g4');
         $chess->put(new Piece(Piece::PAWN, Piece::WHITE), 'h2');
         $fenTmp = $chess->fen();
@@ -178,7 +182,7 @@ class MoveTest extends TestCase
 
         // castling king side
         $fenTmp = 'r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4';
-        $chess->load($fenTmp);
+        $chess = new ChessPublicator($fenTmp);
         $move = (ChessPublicator::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -191,12 +195,12 @@ class MoveTest extends TestCase
         self::assertSame($chess->fen(), 'r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 5 4');
         $chess->undoMovePublic();
         self::assertSame($chess->fen(), $fenTmp);
-        $chess->load($fenStart);
+        $chess = new ChessPublicator($fenStart);
         self::assertSame($chess->fen(), $fenStart);
 
         // castling queen side
         $fenTmp = 'r3kb1r/pppq1ppp/2np1n2/1B2p2b/4P3/3P1N1P/PPPB1PP1/RN1QR1K1 b kq - 2 8';
-        $chess->load($fenTmp);
+        $chess = new ChessPublicator($fenTmp);
         $move = (ChessPublicator::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -209,7 +213,7 @@ class MoveTest extends TestCase
         self::assertSame($chess->fen(), '2kr1b1r/pppq1ppp/2np1n2/1B2p2b/4P3/3P1N1P/PPPB1PP1/RN1QR1K1 w - - 3 9');
         $chess->undoMovePublic();
         self::assertSame($chess->fen(), $fenTmp);
-        $chess->load($fenStart);
+        $chess = new ChessPublicator($fenStart);
         self::assertSame($chess->fen(), $fenStart);
     }
 
@@ -243,7 +247,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'Nf6');
 
         // normal pawn capture
-        $chess->load('rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 2');
+        $chess = new ChessPublicator('rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 2');
         $move = ($chess::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -256,7 +260,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'exd5');
 
         // en passant capture
-        $chess->load('rnbqkbnr/ppp2ppp/8/3Pp3/8/8/PPPP1PPP/RNBQKBNR w KQkq - 0 1');
+        $chess = new ChessPublicator('rnbqkbnr/ppp2ppp/8/3Pp3/8/8/PPPP1PPP/RNBQKBNR w KQkq - 0 1');
         $move = ($chess::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -269,7 +273,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'dxe6');
 
         // normal knight capture
-        $chess->load('rnbqkb1r/ppp1pppp/5n2/3P4/8/5N2/PPPP1PPP/RNBQKB1R b KQkq - 2 3');
+        $chess = new ChessPublicator('rnbqkb1r/ppp1pppp/5n2/3P4/8/5N2/PPPP1PPP/RNBQKB1R b KQkq - 2 3');
         $move = ($chess::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -282,7 +286,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'Nxd5');
 
         // promotion
-        $chess->load('8/2KP4/8/5k2/8/8/8/8 w - - 0 1');
+        $chess = new ChessPublicator('8/2KP4/8/5k2/8/8/8/8 w - - 0 1');
         $move = ($chess::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -296,7 +300,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'd8=R');
 
         // check
-        $chess->load('3R4/2K5/8/5k2/8/8/8/8 w - - 0 1');
+        $chess = new ChessPublicator('3R4/2K5/8/5k2/8/8/8/8 w - - 0 1');
         $move = ($chess::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -309,7 +313,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'Rf8+');
 
         // checkmate
-        $chess->load('5k2/8/1R3K2/8/8/8/8/8 w - - 0 1');
+        $chess = new ChessPublicator('5k2/8/1R3K2/8/8/8/8/8 w - - 0 1');
         $move = ($chess::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -322,7 +326,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'Rb8#');
 
         // ambiguous moves: row
-        $chess->load('2N2k2/8/3p4/8/2N5/8/1K6/8 w - - 0 1');
+        $chess = new ChessPublicator('2N2k2/8/3p4/8/2N5/8/1K6/8 w - - 0 1');
         $move = ($chess::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -335,7 +339,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'N4xd6');
 
         // ambiguous moves: rank > 0 & file > 0
-        $chess->load('8/8/8/2qqq3/2qPq3/2qqq3/1n6/K6k b - - 0 1'); // this one is really ambiguous haha
+        $chess = new ChessPublicator('8/8/8/2qqq3/2qPq3/2qqq3/1n6/K6k b - - 0 1'); // this one is really ambiguous haha
         $move = ($chess::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -348,7 +352,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'Qd5xd4');
 
         // ambiguous moves: col
-        $chess->load('5k2/8/3p4/8/2N1N3/8/1K6/8 w - - 0 1');
+        $chess = new ChessPublicator('5k2/8/3p4/8/2N1N3/8/1K6/8 w - - 0 1');
         $move = ($chess::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -361,7 +365,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'Nexd6');
 
         // ambiguous moves: col
-        $chess->load('5k2/8/3p4/8/2N1N3/8/1K6/8 w - - 0 1');
+        $chess = new ChessPublicator('5k2/8/3p4/8/2N1N3/8/1K6/8 w - - 0 1');
         $move = ($chess::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -374,7 +378,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'Ncxd6');
 
         // ambiguous moves: normal capture
-        $chess->load('5k2/8/3p2R1/8/2N5/8/1K6/8 w - - 0 1');
+        $chess = new ChessPublicator('5k2/8/3p2R1/8/2N5/8/1K6/8 w - - 0 1');
         $move = ($chess::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -387,7 +391,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'Nxd6');
 
         // ambiguous moves: normal capture
-        $chess->load('5k2/8/3p2R1/8/2N5/8/1K6/8 w - - 0 1');
+        $chess = new ChessPublicator('5k2/8/3p2R1/8/2N5/8/1K6/8 w - - 0 1');
         $move = ($chess::buildMovePublic(
             $chess->turn,
             $chess->getBoard(),
@@ -400,7 +404,7 @@ class MoveTest extends TestCase
         self::assertSame($undo->san, 'Rxd6');
 
         // generate moves test
-        $chess->load('8/ppp2P2/pkp5/ppp5/5PPP/5PKP/5PPP/8 w - - 0 1');
+        $chess = new ChessPublicator('8/ppp2P2/pkp5/ppp5/5PPP/5PKP/5PPP/8 w - - 0 1');
         $moves = $chess->generateMovesPublic();
         \array_walk($moves, static function (Move $move) use ($chess): void {
             $chess->moveToSANPublic($move);

--- a/tests/PerftTest.php
+++ b/tests/PerftTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PChess\Chess\Test;
 
-use PChess\Chess\Board;
 use PHPUnit\Framework\TestCase;
 
 // source: https://chessprogramming.wikispaces.com/Perft+Results
@@ -17,7 +16,7 @@ class PerftTest extends TestCase
     {
         $chess = new ChessPublicator($fen);
         self::assertEquals($expectedDeep1, $chess->perft(1));
-        $chess->load(Board::DEFAULT_POSITION);
+        $chess = new ChessPublicator();
         self::assertEquals($expectedDeep2, $chess->perft(2));
     }
 

--- a/tests/PgnTest.php
+++ b/tests/PgnTest.php
@@ -9,18 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 class PgnTest extends TestCase
 {
-    public function testClear(): void
-    {
-        // with clear
-        $chess = new ChessPublicator();
-        $chess->clear();
-        self::assertSame($chess->pgn(), '');
-
-        // without clear
-        $chess = new ChessPublicator();
-        self::assertSame($chess->pgn(), '');
-    }
-
     public function testNormal(): void
     {
         $chess = new ChessPublicator();
@@ -60,7 +48,7 @@ class PgnTest extends TestCase
         $chess->move('e4');
         $fen = $chess->fen();
 
-        $chess->load($fen); // do setup with black first
+        $chess = new ChessPublicator($fen); // do setup with black first
         $chess->move('e5');
         $chess->move('Nf3');
         $chess->move('Nc6');

--- a/tests/PiecePlacementTest.php
+++ b/tests/PiecePlacementTest.php
@@ -33,11 +33,4 @@ class PiecePlacementTest extends TestCase
         $chess->remove('d3');
         self::assertNull($chess->get('d3'));
     }
-
-    public function testInvalidFen(): void
-    {
-        $chess = new Chess('8/8/8/8/8/8/8/8 w KQkq - 0 1');
-        $result = $chess->load('invalid FEN string');
-        self::assertNotNull($result);
-    }
 }


### PR DESCRIPTION
As mentioned in the previous PR, we're removing `clear` and `load` methods from public API.
If someone needs to clear the board, it makes much more sense to instantiate a new `Chess` object (for cases when an empty board is needed, I added a new constant in `Board` class).

I also added a minor sanity check in the `Move` class.