### PR TITLE
✨ add possibility to pass history in constructor

### DIFF
--- a/src/History.php
+++ b/src/History.php
@@ -51,4 +51,9 @@ class History
         $this->halfMoves = $halfMoves;
         $this->moveNumber = $moveNumber;
     }
+
+    public function __toString(): string
+    {
+        return (string) $this->move;
+    }
 }

--- a/src/Move.php
+++ b/src/Move.php
@@ -49,6 +49,11 @@ final class Move implements \JsonSerializable
         $this->promotion = $promotion;
     }
 
+    public function __toString(): string
+    {
+        return (string) $this->san;
+    }
+
     public static function buildMove(
         string $turn,
         Board $board,

--- a/src/Output/HtmlOutput.php
+++ b/src/Output/HtmlOutput.php
@@ -12,9 +12,12 @@ use PChess\Chess\Chess;
  */
 abstract class HtmlOutput implements OutputInterface
 {
-    public function render(Chess $chess, ?string $from = null): string
+    /**
+     * @param mixed $identifier
+     */
+    public function render(Chess $chess, ?string $from = null, $identifier = null): string
     {
-        $links = $this->generateLinks($chess, $from);
+        $links = $this->generateLinks($chess, $from, $identifier);
         $reversed = $chess->board->isReversed();
         $output = '<table id="'.$this->getBoardId().'">';
         /** @var int $i */
@@ -50,12 +53,15 @@ abstract class HtmlOutput implements OutputInterface
      * (according to the result of $chess->moves() method).
      * In second case, you should assign a Link to cancel move start (on the same piece that started the move) to
      * the piece which SAN is identical to $from, and a Link to end move to every legal ending position
-     * (again, according to the result of $chess->moves() method). You must pay attention to special case of
+     * (according to the results of $chess->moves($from) method). You must pay attention to special case of
      * promotion (when piece is a pawn and is in rank 7).
+     * A possible identifier can be passed, to make a distinction between different Chess objects.
+     *
+     * @param mixed $identifier
      *
      * @return array<int, Link>
      */
-    abstract public function generateLinks(Chess $chess, ?string $from = null): array;
+    abstract public function generateLinks(Chess $chess, ?string $from = null, $identifier = null): array;
 
     protected function getBoardId(): string
     {

--- a/tests/ConstructorTest.php
+++ b/tests/ConstructorTest.php
@@ -6,7 +6,10 @@ namespace PChess\Chess\Test;
 
 use Imagine\Image\AbstractImagine;
 use PChess\Chess\Chess;
+use PChess\Chess\History;
+use PChess\Chess\Move;
 use PChess\Chess\Output;
+use PChess\Chess\Piece;
 use PHPUnit\Framework\TestCase;
 
 class ConstructorTest extends TestCase
@@ -23,6 +26,14 @@ class ConstructorTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         new Chess('an invalid fen string');
+    }
+
+    public function testBuildWithHistory(): void
+    {
+        $move = new Move('w', 0, new Piece('p', 'w'), 100, 68);
+        $history = new History($move, ['w' => 116, 'b' => 4], 'b', ['w' => 96, 'b' => 96], null, 0, 1);
+        $chess = new Chess('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1', [$history]);
+        self::assertCount(1, $chess->getHistory());
     }
 
     public function testUnicodeOutput(): void

--- a/tests/GameTest.php
+++ b/tests/GameTest.php
@@ -35,5 +35,6 @@ class GameTest extends TestCase
         $chess = new Chess();
         $chess->move('e4');
         self::assertEquals('e4', $chess->getHistory()[0]->move->san);
+        self::assertEquals('e4', $chess->getHistory()[0]);
     }
 }

--- a/tests/HtmlOutputStub.php
+++ b/tests/HtmlOutputStub.php
@@ -10,7 +10,7 @@ use PChess\Chess\Output\Link;
 
 final class HtmlOutputStub extends HtmlOutput
 {
-    public function generateLinks(Chess $chess, ?string $from = null): array
+    public function generateLinks(Chess $chess, ?string $from = null, $identifier = null): array
     {
         $links = [];
         /** @var int $i */

--- a/tests/MiscTest.php
+++ b/tests/MiscTest.php
@@ -16,26 +16,6 @@ class MiscTest extends TestCase
         foreach ($moves as $move) {
             self::assertNotNull($chess->move($move), $move);
         }
-        self::assertSame($chess->history(), $moves);
-    }
-
-    public function testHistoryPrettyMoves(): void
-    {
-        $chess = new ChessPublicator();
-        $moves = ['e4','e6','d4','d5','Nc3','Nf6','Bg5','dxe4','Nxe4','Be7','Bxf6','gxf6','g3','f5','Nc3','Bf6'];
-
-        foreach ($moves as $move) {
-            self::assertNotNull($chess->move($move), $move);
-        }
-        $histories = $chess->history(true);
-
-        self::assertCount(\count($histories), $moves);
-        foreach ($histories as $k => $history) {
-            if (!\is_object($history)) {
-                continue;
-            }
-            self::assertSame($history->san, $moves[$k]);
-        }
     }
 
     public function testCachedGeneratedMovesHasSAN(): void

--- a/tests/MoveTest.php
+++ b/tests/MoveTest.php
@@ -27,12 +27,12 @@ class MoveTest extends TestCase
             Board::BITS['NORMAL']
         ));
 
-        self::assertSame($move->piece->getType(), Piece::PAWN);
+        self::assertEquals(Piece::PAWN, $move->piece->getType());
         self::assertSame($move->turn, $chess->turn);
         self::assertSame($move->fromSquare, Board::SQUARES['a2']);
         self::assertSame($move->toSquare, Board::SQUARES['a4']);
-        self::assertSame($move->from, 'a2');
-        self::assertSame($move->to, 'a4');
+        self::assertEquals('a2', $move->from);
+        self::assertEquals('a4', $move->to);
         self::assertSame($move->flags, Board::BITS['NORMAL']);
     }
 
@@ -217,6 +217,12 @@ class MoveTest extends TestCase
         self::assertSame($chess->fen(), $fenStart);
     }
 
+    public function testUndoMoveWithEmptyHistory(): void
+    {
+        $chess = new ChessPublicator();
+        self::assertNull($chess->undoMovePublic());
+    }
+
     public function testMoveToSAN(): void
     {
         $chess = new ChessPublicator();
@@ -231,7 +237,8 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'e4');
+        self::assertEquals('e4', $undo->san);
+        self::assertEquals('e4', (string) $undo);
 
         // normal knight move
         $chess->makeMovePublic($move);
@@ -244,7 +251,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'Nf6');
+        self::assertEquals('Nf6', $undo->san);
 
         // normal pawn capture
         $chess = new ChessPublicator('rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 2');
@@ -257,7 +264,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'exd5');
+        self::assertEquals('exd5', $undo->san);
 
         // en passant capture
         $chess = new ChessPublicator('rnbqkbnr/ppp2ppp/8/3Pp3/8/8/PPPP1PPP/RNBQKBNR w KQkq - 0 1');
@@ -270,7 +277,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'dxe6');
+        self::assertEquals('dxe6', $undo->san);
 
         // normal knight capture
         $chess = new ChessPublicator('rnbqkb1r/ppp1pppp/5n2/3P4/8/5N2/PPPP1PPP/RNBQKB1R b KQkq - 2 3');
@@ -283,7 +290,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'Nxd5');
+        self::assertEquals('Nxd5', $undo->san);
 
         // promotion
         $chess = new ChessPublicator('8/2KP4/8/5k2/8/8/8/8 w - - 0 1');
@@ -297,7 +304,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'd8=R');
+        self::assertEquals('d8=R', $undo->san);
 
         // check
         $chess = new ChessPublicator('3R4/2K5/8/5k2/8/8/8/8 w - - 0 1');
@@ -310,7 +317,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'Rf8+');
+        self::assertEquals('Rf8+', $undo->san);
 
         // checkmate
         $chess = new ChessPublicator('5k2/8/1R3K2/8/8/8/8/8 w - - 0 1');
@@ -323,7 +330,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'Rb8#');
+        self::assertEquals('Rb8#', $undo->san);
 
         // ambiguous moves: row
         $chess = new ChessPublicator('2N2k2/8/3p4/8/2N5/8/1K6/8 w - - 0 1');
@@ -336,7 +343,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'N4xd6');
+        self::assertEquals('N4xd6', $undo->san);
 
         // ambiguous moves: rank > 0 & file > 0
         $chess = new ChessPublicator('8/8/8/2qqq3/2qPq3/2qqq3/1n6/K6k b - - 0 1'); // this one is really ambiguous haha
@@ -349,7 +356,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'Qd5xd4');
+        self::assertEquals('Qd5xd4', $undo->san);
 
         // ambiguous moves: col
         $chess = new ChessPublicator('5k2/8/3p4/8/2N1N3/8/1K6/8 w - - 0 1');
@@ -362,7 +369,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'Nexd6');
+        self::assertEquals('Nexd6', $undo->san);
 
         // ambiguous moves: col
         $chess = new ChessPublicator('5k2/8/3p4/8/2N1N3/8/1K6/8 w - - 0 1');
@@ -375,7 +382,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'Ncxd6');
+        self::assertEquals('Ncxd6', $undo->san);
 
         // ambiguous moves: normal capture
         $chess = new ChessPublicator('5k2/8/3p2R1/8/2N5/8/1K6/8 w - - 0 1');
@@ -388,7 +395,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'Nxd6');
+        self::assertEquals('Nxd6', $undo->san);
 
         // ambiguous moves: normal capture
         $chess = new ChessPublicator('5k2/8/3p2R1/8/2N5/8/1K6/8 w - - 0 1');
@@ -401,7 +408,7 @@ class MoveTest extends TestCase
         ));
         $chess->makeMovePublic($move);
         $undo = $chess->undo();
-        self::assertSame($undo->san, 'Rxd6');
+        self::assertEquals('Rxd6', $undo->san);
 
         // generate moves test
         $chess = new ChessPublicator('8/ppp2P2/pkp5/ppp5/5PPP/5PKP/5PPP/8 w - - 0 1');
@@ -521,5 +528,11 @@ class MoveTest extends TestCase
         $chess = new ChessPublicator();
         $moves = $chess->generateMovesPublic(Board::SQUARES['a2'], false);
         self::assertCount(2, $moves);
+    }
+
+    public function testRemoveInvalidSquare(): void
+    {
+        $chess = new Chess();
+        self::assertFalse($chess->remove('invalid'));
     }
 }

--- a/tests/PiecePlacementTest.php
+++ b/tests/PiecePlacementTest.php
@@ -33,4 +33,17 @@ class PiecePlacementTest extends TestCase
         $chess->remove('d3');
         self::assertNull($chess->get('d3'));
     }
+
+    public function testCannotPutMoreThanOneKing(): void
+    {
+        $chess = new Chess();
+        self::assertFalse($chess->put(new Piece(Piece::KING, Piece::WHITE), 'e4'));
+    }
+
+    public function testRemovePieceWithHistory(): void
+    {
+        $chess = new Chess();
+        $chess->move('e4');
+        self::assertTrue($chess->remove('e2'));
+    }
 }


### PR DESCRIPTION
Main feature is described in title.

Some other optimizations:
* remove `history` from main class, since it's only used in PgnOutput (added there with a different name)
* make History and Move stringable
* add the possibility to use an identifier in HtmlOutput
* fix some tests using `assertSame` with swapped arguments